### PR TITLE
Bearer keyword should be title-case

### DIFF
--- a/kii_cloud_api.go
+++ b/kii_cloud_api.go
@@ -172,7 +172,7 @@ func (au *APIAuthor) OnboardGateway(request OnboardGatewayRequest) (*OnboardGate
 		return nil, err
 	}
 	req.Header.Set("content-type", "application/vnd.kii.onboardingWithVendorThingIDByThing+json")
-	req.Header.Set("authorization", "bearer " + au.Token)
+	req.Header.Set("authorization", "Bearer " + au.Token)
 
 	client := &http.Client{}
 	resp, err := client.Do(req)


### PR DESCRIPTION
According to the source code of request.go, 'Basic' keyword for auth is case-sensitive.

https://golang.org/src/net/http/request.go
Line:593

So I think 'Bearer' keyword is same as 'Basic' keyword.
