### PR TITLE
Error imprv

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -931,7 +931,7 @@ func TestDeleteThingScopeBucketFail(t *testing.T) {
 		t.Error("should fail")
 	}
 	code := err.(*CloudError).ErrorCode
-	httpCode := err.(*CloudError).HttpStatus
+	httpCode := err.(*CloudError).HTTPStatus
 	if code != "WRONG_TOKEN" {
 		t.Errorf("unexpected error object: %v+", err)
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -930,6 +930,15 @@ func TestDeleteThingScopeBucketFail(t *testing.T) {
 	if err == nil {
 		t.Error("should fail")
 	}
+	code := err.(CloudError).ErrorCode
+	httpCode := err.(CloudError).HttpStatus
+	if code != "WRONG_TOKEN" {
+		t.Errorf("unexpected error object: %v+", err)
+	}
+	if httpCode != 403 {
+		t.Errorf("unexpected error object: %v+", err)
+	}
+
 }
 
 func TestQueryObjectsFail(t *testing.T) {

--- a/api_test.go
+++ b/api_test.go
@@ -930,8 +930,8 @@ func TestDeleteThingScopeBucketFail(t *testing.T) {
 	if err == nil {
 		t.Error("should fail")
 	}
-	code := err.(CloudError).ErrorCode
-	httpCode := err.(CloudError).HttpStatus
+	code := err.(*CloudError).ErrorCode
+	httpCode := err.(*CloudError).HttpStatus
 	if code != "WRONG_TOKEN" {
 		t.Errorf("unexpected error object: %v+", err)
 	}

--- a/client.go
+++ b/client.go
@@ -3,7 +3,6 @@ package kii
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -69,12 +68,7 @@ func executeRequest2(req *request, scMin, scMax int) ([]byte, error) {
 	logRequest(req.Request, req.body, resp, b)
 
 	if resp.StatusCode < scMin || resp.StatusCode >= scMax {
-		var ce CloudError
-		err = json.Unmarshal(b, &ce)
-		if err != nil {
-			return nil, errors.New(string(b))
-		}
-		ce.HttpStatus = resp.StatusCode
+		ce := newCloudError(resp.StatusCode, b)
 		return nil, ce
 	}
 	return b, nil

--- a/client.go
+++ b/client.go
@@ -69,7 +69,13 @@ func executeRequest2(req *request, scMin, scMax int) ([]byte, error) {
 	logRequest(req.Request, req.body, resp, b)
 
 	if resp.StatusCode < scMin || resp.StatusCode >= scMax {
-		return nil, errors.New(string(b))
+		var ce CloudError
+		err = json.Unmarshal(b, &ce)
+		if err != nil {
+			return nil, errors.New(string(b))
+		}
+		ce.HttpStatus = resp.StatusCode
+		return nil, ce
 	}
 	return b, nil
 }

--- a/error.go
+++ b/error.go
@@ -2,6 +2,7 @@ package kii
 
 import (
 	"fmt"
+	"encoding/json"
 )
 
 // Represents Error Response Returned by Kii Cloud.
@@ -14,6 +15,15 @@ type ErrorResponse struct {
 type CloudError struct {
 	ErrorResponse
 	HttpStatus int
+	RawResponse string
+}
+
+func newCloudError(httpStatus int, rawResponse []byte) *CloudError {
+	var ce CloudError
+	ce.HttpStatus = httpStatus
+	ce.RawResponse = string(rawResponse)
+	json.Unmarshal(rawResponse, &ce)
+	return &ce
 }
 
 func (e CloudError) Error() string {

--- a/error.go
+++ b/error.go
@@ -1,0 +1,21 @@
+package kii
+
+import (
+	"fmt"
+)
+
+// Represents Error Response Returned by Kii Cloud.
+type ErrorResponse struct {
+	ErrorCode string `json:"errorCode"`
+	Message string `json:"message"`
+}
+
+// Represents Error returned by Kii Cloud.
+type CloudError struct {
+	ErrorResponse
+	HttpStatus int
+}
+
+func (e CloudError) Error() string {
+	return fmt.Sprintf("%s : %s (%d)", e.ErrorCode, e.Message, e.HttpStatus)
+}

--- a/error.go
+++ b/error.go
@@ -1,20 +1,20 @@
 package kii
 
 import (
-	"fmt"
 	"encoding/json"
+	"fmt"
 )
 
 // ErrorResponse represents error response returned by Kii Cloud.
 type ErrorResponse struct {
 	ErrorCode string `json:"errorCode"`
-	Message string `json:"message"`
+	Message   string `json:"message"`
 }
 
 // CloudError represents error returned by Kii Cloud.
 type CloudError struct {
 	ErrorResponse
-	HTTPStatus int
+	HTTPStatus  int
 	RawResponse string
 }
 

--- a/error.go
+++ b/error.go
@@ -5,27 +5,27 @@ import (
 	"encoding/json"
 )
 
-// Represents Error Response Returned by Kii Cloud.
+// ErrorResponse represents error response returned by Kii Cloud.
 type ErrorResponse struct {
 	ErrorCode string `json:"errorCode"`
 	Message string `json:"message"`
 }
 
-// Represents Error returned by Kii Cloud.
+// CloudError represents error returned by Kii Cloud.
 type CloudError struct {
 	ErrorResponse
-	HttpStatus int
+	HTTPStatus int
 	RawResponse string
 }
 
 func newCloudError(httpStatus int, rawResponse []byte) *CloudError {
 	var ce CloudError
-	ce.HttpStatus = httpStatus
+	ce.HTTPStatus = httpStatus
 	ce.RawResponse = string(rawResponse)
 	json.Unmarshal(rawResponse, &ce)
 	return &ce
 }
 
 func (e CloudError) Error() string {
-	return fmt.Sprintf("%s : %s (%d)", e.ErrorCode, e.Message, e.HttpStatus)
+	return fmt.Sprintf("%s : %s (%d)", e.ErrorCode, e.Message, e.HTTPStatus)
 }


### PR DESCRIPTION
Using string error is not very friendly.
Changed to return custom error object.

http://blog.golang.org/error-handling-and-go
As suggested in this article, we won't change the return type to *CloudError
